### PR TITLE
Wrong footer link

### DIFF
--- a/website/views/layout.html
+++ b/website/views/layout.html
@@ -129,7 +129,7 @@
 										<a href="/about">About</a>
 									</div>
 									<div class="col-xs-6">
-										<a href="/recipes">Cookbook</a>
+										<a href="/products/cookbook">Cookbook</a>
 										<a href="/recipes">Recipes</a>
 										<a href="/blog">Blog</a>
 										<a href="/contact">Contact</a>


### PR DESCRIPTION
The “Cookbook” link in the footer was linked to the recipes page. I
updated it to link to the Cookbook page